### PR TITLE
Cell render

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,22 @@ self.tabulator.columns = [
 
 If using a Form as the `formatter` then the `data` for the current row will be passed as the `item` allowing data bindings to be used.
 
+If you need the `onRendered` callback. You can add a `cell_render` option to your column definition.
+e.g.
+
+```python
+
+    columns = [
+        ...,
+        {"title": "Sparkline Column", ..., "cell_render": self.sparkline_render},
+    ]
+
+    def sparkline_render(self, cell):
+        el = cell.getElement()
+        jQuery(el).sparkline(cell.getValue(), {"width":"100%", "type":"bar"})
+
+```
+
 
 **Row Selction Formatter**
 

--- a/client_code/Tabulator/_custom_modules.py
+++ b/client_code/Tabulator/_custom_modules.py
@@ -64,7 +64,7 @@ def cell_wrapper(f):
         return lambda cell, **params: f(cell=cell, **params)
     elif hasattr(f, "init_components"):
         # TODO - this could break if trying to use as both an editor and a headerFilter
-        def render_form(cell, on_rendered=None, **params):
+        def render_form(cell, **params):
             data = cell.getData("data")
             if type(data) is JsProxy:
                 data = dict(data)
@@ -72,11 +72,7 @@ def cell_wrapper(f):
 
         return render_form
     else:
-
-        def render_component(cell, on_rendered=None, **params):
-            return f(**params)
-
-        return render_component
+        return lambda cell, **params: f(**params)
 
 
 class AbstractCallableWrapper(AbstractModule):

--- a/client_code/Tabulator/_custom_modules.py
+++ b/client_code/Tabulator/_custom_modules.py
@@ -34,6 +34,7 @@ class ComponentFormatter(AbstractModule):
         self.mod.subscribe("cell-format", self.cell_format)
         self.mod.subscribe("cell-rendered", self.cell_render)
         self.mod.subscribe("cell-delete", self.cell_delete)
+        self.mod.registerColumnOption("cellRender", None)
 
     def cell_format(self, cell, component):
         if not isinstance(component, Component):
@@ -48,6 +49,9 @@ class ComponentFormatter(AbstractModule):
         component = cell.modules.get("anvilComponent")
         if component is not None and component.visible is None:
             component.visible = True
+        renderCallback = cell.column.definition.get("cellRender", None)
+        if renderCallback:
+            renderCallback(cell.getComponent())
 
     def cell_delete(self, cell):
         component = cell.modules.get("anvilComponent")

--- a/client_code/Tabulator/_custom_modules.py
+++ b/client_code/Tabulator/_custom_modules.py
@@ -34,7 +34,9 @@ class ComponentFormatter(AbstractModule):
         self.mod.subscribe("cell-format", self.cell_format)
         self.mod.subscribe("cell-rendered", self.cell_render)
         self.mod.subscribe("cell-delete", self.cell_delete)
+        # because we don't support onRendered callbacks
         self.mod.registerColumnOption("cellRender", None)
+        self.mod.registerColumnOption("cellRenderParams", None)
 
     def cell_format(self, cell, component):
         if not isinstance(component, Component):
@@ -51,7 +53,10 @@ class ComponentFormatter(AbstractModule):
             component.visible = True
         renderCallback = cell.column.definition.get("cellRender", None)
         if renderCallback:
-            renderCallback(cell.getComponent())
+            renderParams = cell.column.definition.get("cellRenderParams", {})
+            if callable(renderParams):
+                renderParams = renderParams()
+            renderCallback(cell.getComponent(), **renderParams)
 
     def cell_delete(self, cell):
         component = cell.modules.get("anvilComponent")

--- a/client_code/Tabulator/_custom_modules.py
+++ b/client_code/Tabulator/_custom_modules.py
@@ -103,12 +103,7 @@ class FormatterWrapper(AbstractCallableWrapper):
     @staticmethod
     def wrap(f):
         f = cell_wrapper(f)
-
-        def wrapped(cell, params, onRendered):
-            params["on_rendered"] = onRendered
-            return f(cell, **params)
-
-        return wrapped
+        return lambda cell, params, onRendered: f(cell, **params)
 
 
 @tabulator_module("sorterWrapper", moduleInitOrder=-10)


### PR DESCRIPTION
@NicoN13

the previous implementation of on_rendered introduced a breaking change
I'd like to revert that and have come up with this alternative

the example in the discussion would become:

```python
    columns_list = [
        ...,   
        {"title": "Sparkline Column", ..., "cell_render": self.sparkline_render},
        ]

    def sparkline_render(self, cell):
        el = cell.getElement()
        jQuery(el).sparkline(cell.getValue(), {"width":"100%", "type":"bar"})
```

I think this is cleaner
Please can you reply to let me know you're happy with this change

(Note you can try this in the development branch, it currently has the `cell_render` option available)

