### PR TITLE
small bug fix on remove_event_handler function

### DIFF
--- a/client_code/Tabulator/__init__.py
+++ b/client_code/Tabulator/__init__.py
@@ -177,7 +177,7 @@ class Tabulator(TabulatorTemplate):
         self.add_event_handler(event, handler)
 
     def remove_event_handler(self, event, handler=None):
-        if event is None:
+        if handler is None:
             super().remove_event_handler(event)
         else:
             super().remove_event_handler(event, handler)


### PR DESCRIPTION
The remove_event_handler function was still not working after the update. I looked quickly and *think* the wrong variable was set in the conditional statement.