### PR TITLE
Defer len() call on search iterator to first access

### DIFF
--- a/client_code/Tabulator/_data_loader.py
+++ b/client_code/Tabulator/_data_loader.py
@@ -61,8 +61,9 @@ _error_to_field = {KeyError: "key", AttributeError: "attribute", TableError: "co
 
 class DataIterator:
     def __init__(self, data_source, data_loader, mutator=None):
+        self._data_source = data_source
         self.iter = iter(data_source)
-        self.len = len(data_source)
+        self._len = None
         self.cache = []
         self.id_field = data_loader.id_field
         self.id_cache = data_loader.id_cache
@@ -73,6 +74,12 @@ class DataIterator:
         self.mutator = mutator
         if self.data_loader.data_initialized:
             self.get_index = self.index_getter
+
+    @property
+    def len(self):
+        if self._len is None:
+            self._len = len(self._data_source)
+        return self._len
 
     def to_dict(self, row):
         as_dict = {}


### PR DESCRIPTION
## Summary

- DataIterator calls len() on the search iterator eagerly in its constructor, causing a separate server round-trip for the row count before the page data is fetched
- This replaces it with a cached property that defers the call to first access, which happens inside get_remote_data alongside the page fetch
- Anvil's client-side request batcher can then combine the count and page fetch into a single round-trip

## Results

Tested against a table with 26k rows:

| Operation | Before | After |
|---|---|---|
| Sort change (26.5k rows) | 3.3-4.2s | 1.6-1.9s |
| Sort + search (70 rows) | 1.6s | 0.8s |

Fully backwards-compatible. All existing code reads `self.len` the same way and gets the same value.